### PR TITLE
Fixed for if you have a complex expression with multiple brackets

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,10 @@ var flattenExpansion = function(set) {
 var findCommon = function(a1, a2) {
   var len = a1.length;
   for (var i = 0; i < len; i++) {
-    if (a1[i] !== a2[i]) return a1.slice(0, i);
+    if (a1[i] !== a2[i]) {
+      if(typeof a1[i - 1] == 'string') return a1.slice(0, i);
+      else return a1.slice(0, i - 2); // fix for double bracket expansion
+    }
   }
   return a1; // identical
 };

--- a/test/main.js
+++ b/test/main.js
@@ -5,45 +5,43 @@ var should = require('should');
 require('mocha');
 
 describe('glob2base', function() {
-  it('should get a base name', function(done) {
+  it('should get a base name', function() {
     var globber = new glob.Glob("js/*.js", {cwd: __dirname});
     glob2base(globber).should.equal("js/");
-    done();
   });
 
-  it('should get a base name from a nested glob', function(done) {
+  it('should get a base name from a nested glob', function() {
     var globber = new glob.Glob("js/**/test/*.js", {cwd: __dirname});
     glob2base(globber).should.equal("js/");
-    done();
   });
 
-  it('should get a base name from a flat file', function(done) {
+  it('should get a base name from a flat file', function() {
     var globber = new glob.Glob("js/test/wow.js", {cwd: __dirname});
     glob2base(globber).should.equal("js/test/");
-    done();
   });
 
-  it('should get a base name from character class pattern', function(done) {
+  it('should get a base name from character class pattern', function() {
     var globber = new glob.Glob("js/t[a-z]st}/*.js", {cwd: __dirname});
     glob2base(globber).should.equal("js/");
-    done();
   });
 
-  it('should get a base name from brace , expansion', function(done) {
+  it('should get a base name from brace , expansion', function() {
     var globber = new glob.Glob("js/{src,test}/*.js", {cwd: __dirname});
     glob2base(globber).should.equal("js/");
-    done();
   });
 
-  it('should get a base name from brace .. expansion', function(done) {
+  it('should get a base name from brace .. expansion', function() {
     var globber = new glob.Glob("js/test{0..9}/*.js", {cwd: __dirname});
     glob2base(globber).should.equal("js/");
-    done();
   });
 
-  it('should get a base name from extglob', function(done) {
+  it('should get a base name from extglob', function() {
     var globber = new glob.Glob("js/t+(wo|est)/*.js", {cwd: __dirname});
     glob2base(globber).should.equal("js/");
-    done();
+  });
+
+  it('should get a base name from a complex brace glob', function() {
+    var globber = new glob.Glob("lib/{components,pages}/**/{test,another}/*.txt", {cwd: __dirname});
+    glob2base(globber).should.equal("lib/");
   });
 });


### PR DESCRIPTION
As it was, it was resulting in the blank object from minimatch if you had double bracket expressions in the same statement. As such your path would be `lib/some-dir/[object Object]`. This basically checks for that and returns the proper expression.
