### PR TITLE
Expose interface that accepts minimatch instance instead of glob instanc...

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,12 @@ var setToBase = function(set) {
 
 module.exports = function(glob) {
   var set = glob.minimatch.set;
-  var baseParts = setToBase(set);
+  return minimatchToBase(set);
+};
+
+var minimatchToBase = module.exports.minimatch = function(minimatchSet) {
+  var baseParts = setToBase(minimatchSet);
   var basePath = path.normalize(baseParts.join(path.sep))+path.sep;
   return basePath;
 };
+


### PR DESCRIPTION
Hi fractals,
I'm working on a fake file system based on the awesome vinyl. The new babe is called `[vinyl-fs-mock](https://github.com/timnew/vinyl-fs-mock)`, which can be used tests of  `gulp` plugins. 

I wish that sooner or later, we can test `gulp` plugin or any code based on `vinyl` and `vinyl-fs` stream without dependent on real file fixtures. The goal of this project could be similar to your guys' [vinyl-fs-tree](https://github.com/wearefractal/vinyl-fs-tree), which doesn't look like a finished project and is not as flexible as I expected.

Now I'm working on the glob support part, to make it as much compatible with `gulp` as possible. The implementation has been almost done. I'm dealing with some path and base path issue. The glob2base is likely to be used. 

The issue I met is that I only depends on `minimatch` but `glob`, so I wish `glob2base` publish a interface for `minimatch` instead as well as `glob` 
