### PR TITLE
Fix undefined index error

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,14 @@ var findIndex = require('find-index');
 var flattenGlob = function(arr){
   var out = [];
   var flat = true;
-  for(var i = 0; i < arr.length; i++) {
-    if (typeof arr[i] !== 'string') {
-      flat = false;
-      break;
+  if(Array.isArray(arr)) {
+    for (var i = 0; i < arr.length; i++) {
+      if (typeof arr[i] !== 'string') {
+        flat = false;
+        break;
+      }
+      out.push(arr[i]);
     }
-    out.push(arr[i]);
   }
 
   // last one is a file or specific dir


### PR DESCRIPTION
`arr` atribute can be string or array, so sometimes we have error: 

> TypeError: Cannot read property 'length' of undefined
